### PR TITLE
Update CMakeLists to generate corresponding msgs

### DIFF
--- a/flightgoggles_marker_visualizer/CMakeLists.txt
+++ b/flightgoggles_marker_visualizer/CMakeLists.txt
@@ -36,6 +36,8 @@ include_directories(${catkin_INCLUDE_DIRS} ${SDL_INCLUDE_DIR})
 
 add_executable(flightgoggles_marker_visualizer src/flightgoggles_marker_visualizer_node.cpp)
 
+add_dependencies(flightgoggles_marker_visualizer ${catkin_EXPORTED_TARGETS})
+
 target_link_libraries(flightgoggles_marker_visualizer
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}


### PR DESCRIPTION
Currently building on kinetic, catkin_make is reporting couldn't find `IRMarkerArray.h`, add_dependencies to force IRMarkerArray dependencies generation